### PR TITLE
Log documents that failed to be ingested

### DIFF
--- a/langchain_weaviate/vectorstores.py
+++ b/langchain_weaviate/vectorstores.py
@@ -189,6 +189,15 @@ class WeaviateVectorStore(VectorStore):
                 )
 
                 ids.append(_id)
+
+        failed_objs = self._client.batch.failed_objects
+        for obj in failed_objs:
+            err_message = (
+                f"Failed to add object: {obj.original_uuid}\nReason: {obj.message}"
+            )
+
+            logger.error(err_message)
+
         return ids
 
     def _perform_search(


### PR DESCRIPTION
Fixes langchain-ai/langchain#2772

If a list of documents have some good and bad documents e.g. using a reserved keyword, then:

1. the good documents will be ingested
2. the uuid and the reason the bad docs could not be ingested are logged (ERROR level) to stdout