### PR TITLE
fix(vectorstores.py): fetch embedding for the `near_vector` method

### DIFF
--- a/langchain_weaviate/vectorstores.py
+++ b/langchain_weaviate/vectorstores.py
@@ -255,7 +255,12 @@ class WeaviateVectorStore(VectorStore):
                         query=query, vector=embedding, limit=k, **kwargs
                     )
                 elif search_method == "near_vector":
-                    result = collection.query.near_vector(limit=k, **kwargs)
+                    embedding = self._embedding.embed_query(query)
+                    result = collection.query.near_vector(
+                        near_vector = embedding, 
+                        limit=k, 
+                        **kwargs
+                    )
                 else:
                     raise ValueError(f"Invalid search method: {search_method}")
             except weaviate.exceptions.WeaviateQueryException as e:

--- a/langchain_weaviate/vectorstores.py
+++ b/langchain_weaviate/vectorstores.py
@@ -257,9 +257,7 @@ class WeaviateVectorStore(VectorStore):
                 elif search_method == "near_vector":
                     embedding = self._embedding.embed_query(query)
                     result = collection.query.near_vector(
-                        near_vector = embedding, 
-                        limit=k, 
-                        **kwargs
+                        near_vector=embedding, limit=k, **kwargs
                     )
                 else:
                     raise ValueError(f"Invalid search method: {search_method}")


### PR DESCRIPTION
* Solves this issue: #132 

The `near_vector` method accepts a parameter called "near_vector", for which the method will perform vector search to get the nearest vector(s). We should get the vector using the embedding object, just as we did in the `hybrid` search method, 4 lines above it.
