### PR TITLE
remove similarity_search_by_vector

### DIFF
--- a/langchain_weaviate/vectorstores.py
+++ b/langchain_weaviate/vectorstores.py
@@ -302,19 +302,6 @@ class WeaviateVectorStore(VectorStore):
         result = self._perform_search(query, k, **kwargs)
         return result
 
-    def similarity_search_by_vector(
-        self, embedding: List[float], k: int = 4, **kwargs: Any
-    ) -> List[Document]:
-        """Look up similar documents by embedding vector in Weaviate."""
-
-        return self._perform_search(
-            query=None,
-            k=k,
-            near_vector=embedding,
-            search_method="near_vector",
-            **kwargs,
-        )
-
     def max_marginal_relevance_search(
         self,
         query: str,

--- a/tests/integration_tests/test_vectorstores.py
+++ b/tests/integration_tests/test_vectorstores.py
@@ -288,7 +288,7 @@ def test_add_texts_with_given_embedding(
     )
 
     docsearch.add_texts(["foo"])
-    output = docsearch.similarity_search_by_vector(embedding.embed_query("foo"), k=2)
+    output = docsearch.similarity_search("foo", alpha=1, k=2)
     assert output == [
         Document(page_content="foo"),
         Document(page_content="foo"),
@@ -309,7 +309,7 @@ def test_add_texts_with_given_uuids(
 
     # Weaviate replaces the object if the UUID already exists
     docsearch.add_texts(["foo"], uuids=[uuids[0]])
-    output = docsearch.similarity_search_by_vector(embedding.embed_query("foo"), k=2)
+    output = docsearch.similarity_search("foo", alpha=1, k=2)
     assert output[0] == Document(page_content="foo")
     assert output[1] != Document(page_content="foo")
 


### PR DESCRIPTION
Remove `similarity_search_by_vector` since the same function can be done by hybrid search

Fixes:

* #132
* # 131

Signed-off-by: hsm207 <hsm207@users.noreply.github.com>