### PR TITLE
[Enhancement] Support for specifying vectorizer parameter

### DIFF
--- a/libs/weaviate/langchain_weaviate/vectorstores.py
+++ b/libs/weaviate/langchain_weaviate/vectorstores.py
@@ -92,6 +92,7 @@ class WeaviateVectorStore(VectorStore):
         text_key: str,
         embedding: Optional[Embeddings] = None,
         attributes: Optional[List[str]] = None,
+        vectorizer: Optional[str] = None,
         relevance_score_fn: Optional[
             Callable[[float], float]
         ] = _default_score_normalizer,
@@ -115,7 +116,8 @@ class WeaviateVectorStore(VectorStore):
 
         schema = _default_schema(self._index_name)
         schema["MultiTenancyConfig"] = {"enabled": use_multi_tenancy}
-
+        if vectorizer:
+            schema["vectorizer"] = vectorizer
         # check whether the index already exists
         if not client.collections.exists(self._index_name):
             client.collections.create_from_dict(schema)


### PR DESCRIPTION
feat: https://github.com/langchain-ai/langchain-weaviate/issues/95

I have added a optional parameter of `vectorizer` to the Vectorstore class 
The hierarchy it follows is :-

1. If a vectorizer is passed for example `text2vec-transformers`, the class will be created with the passed value.
2. If nothing is passed to it then it will adopt the `DEFAULT_VECTORIZER ` from the Weaviate configuration
3. If the user does not want any vectorizers they can pass `none` as a string in the vectorizer param as well