### PR TITLE
allow passing an empty docs [] to from_documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 __pycache__
 .coverage
 dist
+.venv

--- a/libs/weaviate/langchain_weaviate/vectorstores.py
+++ b/libs/weaviate/langchain_weaviate/vectorstores.py
@@ -161,7 +161,7 @@ class WeaviateVectorStore(VectorStore):
 
         ids = []
         embeddings: Optional[List[List[float]]] = None
-        if self._embedding:
+        if self._embedding and texts:
             embeddings = self._embedding.embed_documents(list(texts))
 
         with self._client.batch.dynamic() as batch:
@@ -471,7 +471,6 @@ class WeaviateVectorStore(VectorStore):
                     client=client
                 )
         """
-
         attributes = list(metadatas[0].keys()) if metadatas else None
 
         weaviate_vector_store = cls(


### PR DESCRIPTION
passing an empty list as docs was failing for some embedders:

```
embeddings2 = CohereEmbeddings(
    model="embed-english-v3.0",
)
weaviate_client = weaviate.connect_to_local()
db = WeaviateVectorStore.from_documents([], embeddings2, client=weaviate_client)
```

this will prevent embedding empty texts.

it was raising this error:

>   File "/Users/I747411/ai/venv/lib/python3.10/site-packages/sentence_transformers/SentenceTransformer.py", line 565, in encode
>     if all_embeddings[0].dtype == torch.bfloat16:
> IndexError: list index out of range