### PR TITLE
Update GitHub Actions workflow permissions

### DIFF
--- a/.github/workflows/update-weaviate-server.yml
+++ b/.github/workflows/update-weaviate-server.yml
@@ -7,6 +7,10 @@ on:
 env:
   SOURCE_BRANCH_NAME: update-weaviate-image
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-version:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add write permissions for contents and pull requests in the GitHub Actions workflow so that it can commit version updates.