### PR TITLE
langchain-weaviate: refine code to support weaviate with SemanticSimi…

### DIFF
--- a/libs/weaviate/langchain_weaviate/vectorstores.py
+++ b/libs/weaviate/langchain_weaviate/vectorstores.py
@@ -468,9 +468,12 @@ class WeaviateVectorStore(VectorStore):
         """
 
         attributes = list(metadatas[0].keys()) if metadatas else None
-
+        client = client or kwargs["vectorstore_cls_kwargs"]["client"]
         if client is None:
             raise ValueError("client must be an instance of WeaviateClient")
+
+        index_name = index_name or kwargs["vectorstore_cls_kwargs"]["index_name"]
+        text_key = text_key or kwargs["vectorstore_cls_kwargs"]["text_key"]
 
         weaviate_vector_store = cls(
             client,


### PR DESCRIPTION
```python
from langchain_weaviate.vectorstores import WeaviateVectorStore
from langchain_core.example_selectors import SemanticSimilarityExampleSelector

with weaviate.connect_to_embedded() as client:
    client.is_ready()
    example_selector = SemanticSimilarityExampleSelector.from_examples(
        examples=examples,
        embeddings=embeddings,
        vectorstore_cls= WeaviateVectorStore,
        vectorstore_cls_kwargs={"index_name": "example_index", "text_key": "input", "client": client},
        k=2,
    )

    few_shot_chat_message = FewShotChatMessagePromptTemplate(
        input_variables=["input"],
        example_selector=example_selector,
        example_prompt=ChatPromptTemplate.from_messages(
             [("human", "{input}"), ("ai", "{output}")]
         ),
    )
    print(few_shot_chat_message.invoke(input="What's 3 🦜 3?").to_messages())
```

above code, using SemanticSimilarityExampleSelector.from_examples method but can not correct get Weaviate client, so support init weaviate client outside and pass by vectorstore_cls_kwargs.
