### PR TITLE
Fix: Ensure WeaviateVectorStore closes client on garbage collection

### DIFF
--- a/libs/weaviate/langchain_weaviate/vectorstores.py
+++ b/libs/weaviate/langchain_weaviate/vectorstores.py
@@ -538,3 +538,6 @@ class WeaviateVectorStore(VectorStore):
             yield self._collection.with_tenant(tenant)
         finally:
             pass
+
+    def __del__(self) -> None:
+        self._client.close()


### PR DESCRIPTION
- Ensures WeaviateVectorStore proactively closes its underlying Weaviate client when the store instance is garbage collected.
- Prevents resource leaks and stray open connections that could lead to intermittent test hangs, socket warnings, or exhausted connection pools.
