### PR TITLE
fix(weaviate): raise on batch indexing failures in add_texts

### DIFF
--- a/libs/weaviate/langchain_weaviate/vectorstores.py
+++ b/libs/weaviate/langchain_weaviate/vectorstores.py
@@ -199,12 +199,23 @@ class WeaviateVectorStore(VectorStore):
                 ids.append(_id)
 
         failed_objs = self._client.batch.failed_objects
+        failed_uuids = {str(obj.original_uuid) for obj in failed_objs}
         for obj in failed_objs:
             err_message = (
                 f"Failed to add object: {obj.original_uuid}\nReason: {obj.message}"
             )
 
             logger.error(err_message)
+
+        ids = [obj_id for obj_id in ids if str(obj_id) not in failed_uuids]
+        if failed_objs:
+            error = ValueError(
+                "Failed to index "
+                f"{len(failed_objs)} out of {len(failed_objs) + len(ids)} objects into "
+                f"Weaviate. First failure: {failed_objs[0].message}"
+            )
+            setattr(error, "successful_ids", ids)
+            raise error
 
         return ids
 

--- a/libs/weaviate/tests/unit_tests/test_vectorstores_unit.py
+++ b/libs/weaviate/tests/unit_tests/test_vectorstores_unit.py
@@ -249,3 +249,43 @@ def test_vectorstore_with_multi_tenancy_bool_false() -> None:
 
     # Should create config with multi-tenancy disabled
     assert vectorstore.schema["MultiTenancyConfig"]["enabled"] is False
+
+
+def test_add_texts_raises_value_error_on_batch_failures() -> None:
+    """Test that add_texts surfaces batch indexing failures."""
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock
+
+    mock_client = MagicMock()
+    mock_client.collections.exists.return_value = True
+    mock_config = mock_client.collections.get.return_value.config.get.return_value
+    mock_config.multi_tenancy_config.enabled = False
+
+    mock_batch = MagicMock()
+    mock_client.batch.dynamic.return_value.__enter__.return_value = mock_batch
+    mock_client.batch.failed_objects = [
+        SimpleNamespace(
+            original_uuid="22222222-2222-2222-2222-222222222222",
+            message="boom",
+        )
+    ]
+
+    vectorstore = WeaviateVectorStore(
+        client=mock_client,
+        index_name="TestClass",
+        text_key="text",
+    )
+
+    with pytest.raises(
+        ValueError, match="Failed to index 1 out of 2 objects into Weaviate"
+    ) as exc_info:
+        vectorstore.add_texts(
+            ["foo", "bar"],
+            ids=[
+                "11111111-1111-1111-1111-111111111111",
+                "22222222-2222-2222-2222-222222222222",
+            ],
+        )
+    assert getattr(exc_info.value, "successful_ids") == [
+        "11111111-1111-1111-1111-111111111111"
+    ]


### PR DESCRIPTION
## Summary

`add_texts()` now raises a `ValueError` when Weaviate batch indexing fails, instead of silently logging errors and returning all IDs as if everything succeeded.

Fixes langchain-ai/langchain#35572

## Problem

`WeaviateVectorStore.add_texts()` calls `self._client.batch.failed_objects` after batch indexing, logs any failures, but still returns the full list of IDs — giving callers no indication that some objects weren't actually indexed. This is especially problematic in FastAPI apps where the LangChain logger may not be attached.

## Changes

**`libs/weaviate/langchain_weaviate/vectorstores.py`**
- After logging failures, filter failed UUIDs out of the returned `ids` list
- Raise `ValueError` with a descriptive message: count of failures, total attempted, and first error
- Attach `successful_ids` attribute to the exception for partial recovery (`getattr(e, 'successful_ids', [])`)

**`libs/weaviate/tests/unit_tests/test_vectorstores_unit.py`**
- Added `test_add_texts_raises_value_error_on_batch_failures()` — mocks one failed object out of two, asserts `ValueError` is raised with correct message and `successful_ids` contains only the non-failed ID

## Backward Compatibility

This is a behavior change from silent failure to raising. However, silent data loss on batch indexing is a bug, not a feature — callers relying on the previous behavior were already losing data without knowing it.