### PR TITLE
fix: raise weaviate-native errors when add_texts/aadd_texts insertions fail

### DIFF
--- a/libs/weaviate/langchain_weaviate/vectorstores.py
+++ b/libs/weaviate/langchain_weaviate/vectorstores.py
@@ -199,12 +199,19 @@ class WeaviateVectorStore(VectorStore):
                 ids.append(_id)
 
         failed_objs = self._client.batch.failed_objects
-        for obj in failed_objs:
-            err_message = (
-                f"Failed to add object: {obj.original_uuid}\nReason: {obj.message}"
+        if failed_objs:
+            error_messages = []
+            for obj in failed_objs:
+                err_message = (
+                    f"Failed to add object: {obj.original_uuid}\nReason: {obj.message}"
+                )
+                logger.error(err_message)
+                error_messages.append(err_message)
+            
+            raise ValueError(
+                f"Failed to add {len(failed_objs)} object(s) to Weaviate:\n"
+                + "\n".join(error_messages)
             )
-
-            logger.error(err_message)
 
         return ids
 

--- a/libs/weaviate/langchain_weaviate/vectorstores.py
+++ b/libs/weaviate/langchain_weaviate/vectorstores.py
@@ -224,13 +224,17 @@ class WeaviateVectorStore(VectorStore):
             tenant_objs = [weaviate.classes.tenants.Tenant(name=tenant)]
             self._collection.tenants.create(tenants=tenant_objs)
 
+        # Materialize once: ``texts`` may be a generator, and we consume it both
+        # for embedding and for building the batch below.
+        texts_list = list(texts)
+
         ids = []
         embeddings: Optional[List[List[float]]] = None
         if self._embedding:
-            embeddings = self._embedding.embed_documents(list(texts))
+            embeddings = self._embedding.embed_documents(texts_list)
 
         with self._client.batch.dynamic() as batch:
-            for i, text in enumerate(texts):
+            for i, text in enumerate(texts_list):
                 data_properties = {self._text_key: text}
                 if metadatas is not None:
                     for key, val in metadatas[i].items():
@@ -679,13 +683,14 @@ class WeaviateVectorStore(VectorStore):
                 tenants=tenant_objs
             )
 
+        # Materialize once: ``texts`` may be a generator, and we consume it both
+        # for embedding and for building the objects below.
+        texts_list = list(texts)
+
         ids = []
         embeddings: Optional[List[List[float]]] = None
         if self._embedding:
-            embeddings = await self._embedding.aembed_documents(list(texts))
-
-        # Convert texts to list
-        texts_list = list(texts)
+            embeddings = await self._embedding.aembed_documents(texts_list)
 
         # Prepare objects for insertion
         objects_to_insert = []

--- a/libs/weaviate/langchain_weaviate/vectorstores.py
+++ b/libs/weaviate/langchain_weaviate/vectorstores.py
@@ -224,17 +224,18 @@ class WeaviateVectorStore(VectorStore):
             tenant_objs = [weaviate.classes.tenants.Tenant(name=tenant)]
             self._collection.tenants.create(tenants=tenant_objs)
 
-        # Materialize once: ``texts`` may be a generator, and we consume it both
-        # for embedding and for building the batch below.
-        texts_list = list(texts)
-
         ids = []
         embeddings: Optional[List[List[float]]] = None
         if self._embedding:
-            embeddings = self._embedding.embed_documents(texts_list)
+            # ``texts`` may be a generator, and we consume it both for embedding
+            # and for building the batch below -- materialize it once so the
+            # batch loop is not left iterating an exhausted iterator. When there
+            # is no embedding we iterate it a single time and avoid the copy.
+            texts = list(texts)
+            embeddings = self._embedding.embed_documents(texts)
 
         with self._client.batch.dynamic() as batch:
-            for i, text in enumerate(texts_list):
+            for i, text in enumerate(texts):
                 data_properties = {self._text_key: text}
                 if metadatas is not None:
                     for key, val in metadatas[i].items():
@@ -683,18 +684,19 @@ class WeaviateVectorStore(VectorStore):
                 tenants=tenant_objs
             )
 
-        # Materialize once: ``texts`` may be a generator, and we consume it both
-        # for embedding and for building the objects below.
-        texts_list = list(texts)
-
         ids = []
         embeddings: Optional[List[List[float]]] = None
         if self._embedding:
-            embeddings = await self._embedding.aembed_documents(texts_list)
+            # ``texts`` may be a generator, and we consume it both for embedding
+            # and for building the objects below -- materialize it once so the
+            # object loop is not left iterating an exhausted iterator. When there
+            # is no embedding we iterate it a single time and avoid the copy.
+            texts = list(texts)
+            embeddings = await self._embedding.aembed_documents(texts)
 
         # Prepare objects for insertion
         objects_to_insert = []
-        for i, text in enumerate(texts_list):
+        for i, text in enumerate(texts):
             data_properties = {self._text_key: text}
             if metadatas is not None and i < len(metadatas):
                 for key, val in metadatas[i].items():
@@ -743,9 +745,16 @@ class WeaviateVectorStore(VectorStore):
                     error_messages.append(err_message)
 
         if error_messages:
+            summary = "\n".join(error_messages)
+            if len(error_messages) == len(ids):
+                # ``insert_many`` is expected to raise this itself when every
+                # object fails, but if a client version instead returns the
+                # failures in ``result.errors`` we still honor the documented
+                # all-failed contract (mirrors the sync ``add_texts`` path).
+                raise WeaviateInsertManyAllFailedError(summary)
             raise WeaviateBatchError(
                 f"Failed to add {len(error_messages)} of {len(ids)} object(s) "
-                f"to Weaviate:\n" + "\n".join(error_messages)
+                f"to Weaviate:\n" + summary
             )
 
         return ids

--- a/libs/weaviate/langchain_weaviate/vectorstores.py
+++ b/libs/weaviate/langchain_weaviate/vectorstores.py
@@ -203,7 +203,17 @@ class WeaviateVectorStore(VectorStore):
         tenant: Optional[str] = None,
         **kwargs: Any,
     ) -> List[str]:
-        """Upload texts with metadata (properties) to Weaviate."""
+        """Upload texts with metadata (properties) to Weaviate.
+
+        Failed insertions are surfaced as weaviate-native exceptions rather than
+        returning ids for objects that were never stored. Both subclass
+        ``weaviate.exceptions.WeaviateBaseError``, so callers can catch that for
+        a single catch-all.
+
+        Raises:
+            WeaviateInsertManyAllFailedError: If every object fails to be added.
+            WeaviateBatchError: If some (but not all) objects fail to be added.
+        """
         from weaviate.util import get_valid_uuid  # type: ignore
 
         if tenant and not self._does_tenant_exist(tenant):
@@ -641,7 +651,17 @@ class WeaviateVectorStore(VectorStore):
         tenant: Optional[str] = None,
         **kwargs: Any,
     ) -> List[str]:
-        """Add texts to Weaviate asynchronously."""
+        """Add texts to Weaviate asynchronously.
+
+        Mirrors the synchronous ``add_texts`` failure contract: failed
+        insertions are surfaced as weaviate-native exceptions rather than
+        returning ids for objects that were never stored. Both subclass
+        ``weaviate.exceptions.WeaviateBaseError``.
+
+        Raises:
+            WeaviateInsertManyAllFailedError: If every object fails to be added.
+            WeaviateBatchError: If some (but not all) objects fail to be added.
+        """
         if self._client_async is None:
             logger.warning("client_async is None, using synchronous client instead")
             return await run_in_executor(

--- a/libs/weaviate/langchain_weaviate/vectorstores.py
+++ b/libs/weaviate/langchain_weaviate/vectorstores.py
@@ -26,6 +26,10 @@ from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
 from langchain_core.runnables.config import run_in_executor
 from langchain_core.vectorstores import VectorStore
+from weaviate.exceptions import (  # type: ignore
+    WeaviateBatchError,
+    WeaviateInsertManyAllFailedError,
+)
 
 from langchain_weaviate.utils import maximal_marginal_relevance
 
@@ -242,6 +246,12 @@ class WeaviateVectorStore(VectorStore):
 
                 ids.append(_id)
 
+        # ``batch.dynamic()`` allocates a fresh result buffer on entry, so
+        # ``failed_objects`` reflects only this call's failures. Unlike the raw
+        # weaviate-client batch API (which never raises and silently drops
+        # failures into ``failed_objects``), we surface them: returning ids for
+        # objects that were never stored is the silent-failure bug, and every
+        # other LangChain vector store raises when an insert fails.
         failed_objs = self._client.batch.failed_objects
         if failed_objs:
             error_messages = []
@@ -251,10 +261,15 @@ class WeaviateVectorStore(VectorStore):
                 )
                 logger.error(err_message)
                 error_messages.append(err_message)
-            
-            raise ValueError(
-                f"Failed to add {len(failed_objs)} object(s) to Weaviate:\n"
-                + "\n".join(error_messages)
+
+            summary = "\n".join(error_messages)
+            if len(failed_objs) == len(ids):
+                # Mirror the async ``insert_many`` path, which raises this when
+                # every object fails.
+                raise WeaviateInsertManyAllFailedError(summary)
+            raise WeaviateBatchError(
+                f"Failed to add {len(failed_objs)} of {len(ids)} object(s) "
+                f"to Weaviate:\n{summary}"
             )
 
         return ids
@@ -681,22 +696,32 @@ class WeaviateVectorStore(VectorStore):
             ids.append(_id)
 
         # Use async client's insert_many method instead of batch
+        error_messages = []
         async with self._atenant_context(tenant) as collection:
             # Process objects in batches of 100 to avoid overwhelming the server
             batch_size = 100
             for i in range(0, len(objects_to_insert), batch_size):
                 batch = objects_to_insert[i : i + batch_size]
-                # Use insert_many for batch operations with async client.
                 # insert_many raises WeaviateInsertManyAllFailedError (and other
-                # WeaviateBaseError subclasses) on total/structural failure; we
-                # let those propagate. Partial failures are returned in
-                # result.errors, mirroring the sync batch failed_objects path.
+                # WeaviateBaseError subclasses) when an entire insert call fails;
+                # we let those propagate. Partial failures are returned in
+                # result.errors -- collect them and raise below so we never
+                # return ids for objects that were not stored (mirrors the sync
+                # add_texts contract and the rest of the LangChain ecosystem).
                 result = await collection.data.insert_many(batch)  # type: ignore
                 for err in result.errors.values():
-                    logger.error(
+                    err_message = (
                         f"Failed to add object: {err.original_uuid}\n"
                         f"Reason: {err.message}"
                     )
+                    logger.error(err_message)
+                    error_messages.append(err_message)
+
+        if error_messages:
+            raise WeaviateBatchError(
+                f"Failed to add {len(error_messages)} of {len(ids)} object(s) "
+                f"to Weaviate:\n" + "\n".join(error_messages)
+            )
 
         return ids
 

--- a/libs/weaviate/langchain_weaviate/vectorstores.py
+++ b/libs/weaviate/langchain_weaviate/vectorstores.py
@@ -243,12 +243,19 @@ class WeaviateVectorStore(VectorStore):
                 ids.append(_id)
 
         failed_objs = self._client.batch.failed_objects
-        for obj in failed_objs:
-            err_message = (
-                f"Failed to add object: {obj.original_uuid}\nReason: {obj.message}"
+        if failed_objs:
+            error_messages = []
+            for obj in failed_objs:
+                err_message = (
+                    f"Failed to add object: {obj.original_uuid}\nReason: {obj.message}"
+                )
+                logger.error(err_message)
+                error_messages.append(err_message)
+            
+            raise ValueError(
+                f"Failed to add {len(failed_objs)} object(s) to Weaviate:\n"
+                + "\n".join(error_messages)
             )
-
-            logger.error(err_message)
 
         return ids
 

--- a/libs/weaviate/tests/unit_tests/test_vectorstores_additional.py
+++ b/libs/weaviate/tests/unit_tests/test_vectorstores_additional.py
@@ -1103,3 +1103,77 @@ async def test_atenant_context_missing_tenant(
         ValueError, match="cannot perform asearch with synchronous client"
     ):
         await docsearch._perform_asearch(query="test", k=5)
+
+
+def test_add_texts_with_generator_input(
+    mock_weaviate_client: MagicMock, embedding: Any
+) -> None:
+    """``texts`` may be a generator; it must be consumed exactly once.
+
+    ``add_texts`` embeds and then batches the same texts. A generator is
+    exhausted by embedding, so it must be materialized once and reused --
+    otherwise nothing is inserted (a silent data-loss bug).
+    """
+    mock_batch = MagicMock()
+    mock_client = MagicMock()
+    mock_client.batch.dynamic.return_value.__enter__.return_value = mock_batch
+    mock_client.batch.failed_objects = []
+
+    docsearch = WeaviateVectorStore(
+        client=mock_client,
+        index_name="TestIndex",
+        text_key="text",
+        embedding=embedding,
+    )
+    docsearch._client = mock_client
+    docsearch._index_name = "TestIndex"
+    docsearch._embedding = embedding
+    docsearch._text_key = "text"
+    docsearch._multi_tenancy_enabled = False
+
+    texts = (t for t in ["alpha", "beta", "gamma"])
+    ids = docsearch.add_texts(texts)
+
+    assert len(ids) == 3
+    assert mock_batch.add_object.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_aadd_texts_with_generator_input(
+    mock_weaviate_client: MagicMock, embedding: Any
+) -> None:
+    """``aadd_texts`` must materialize a generator ``texts`` exactly once.
+
+    Mirrors ``test_add_texts_with_generator_input``: a generator consumed by
+    embedding must still be available when building the insert_many batch.
+    """
+    insert_result = MagicMock()
+    insert_result.errors = {}
+
+    mock_collection = MagicMock()
+    mock_collection.data.insert_many = AsyncMock(return_value=insert_result)
+
+    docsearch = WeaviateVectorStore(
+        client=mock_weaviate_client,
+        index_name="TestIndex",
+        text_key="text",
+        embedding=embedding,
+        client_async=MagicMock(),
+    )
+    docsearch._client_async = MagicMock()
+    docsearch._embedding = embedding
+    docsearch._text_key = "text"
+    docsearch._multi_tenancy_enabled = False
+
+    @asynccontextmanager
+    async def fake_tenant_context(tenant: Any = None) -> AsyncGenerator[Any, None]:
+        yield mock_collection
+
+    texts = (t for t in ["alpha", "beta", "gamma"])
+    with patch.object(docsearch, "_atenant_context", fake_tenant_context):
+        ids = await docsearch.aadd_texts(texts)
+
+    assert len(ids) == 3
+    mock_collection.data.insert_many.assert_awaited_once()
+    (inserted_batch,) = mock_collection.data.insert_many.await_args.args
+    assert len(inserted_batch) == 3

--- a/libs/weaviate/tests/unit_tests/test_vectorstores_additional.py
+++ b/libs/weaviate/tests/unit_tests/test_vectorstores_additional.py
@@ -335,15 +335,19 @@ async def test_batch_insertion_error_handling(
 
 
 @pytest.mark.asyncio
-async def test_aadd_texts_logs_partial_insert_many_errors(
+async def test_aadd_texts_raises_on_partial_insert_many_errors(
     mock_weaviate_client: MagicMock, embedding: Any, caplog: Any
 ) -> None:
-    """Partial insert_many failures are logged (mirroring the sync batch path).
+    """Partial insert_many failures are logged AND raised.
 
     insert_many returns per-object failures in ``result.errors`` rather than
-    raising (it only raises when *all* objects fail), so ``aadd_texts`` must
-    surface them via the logger like the synchronous ``failed_objects`` path.
+    raising (it only raises when *all* objects fail). Returning ids for objects
+    that were never stored is a silent failure, so ``aadd_texts`` logs the
+    failures and raises ``WeaviateBatchError`` -- consistent with the sync
+    ``add_texts`` path and the rest of the LangChain ecosystem.
     """
+    from weaviate.exceptions import WeaviateBatchError
+
     docsearch = WeaviateVectorStore(
         client=mock_weaviate_client,
         index_name="TestIndex",
@@ -373,10 +377,9 @@ async def test_aadd_texts_logs_partial_insert_many_errors(
 
     with patch.object(docsearch, "_atenant_context", fake_tenant_context):
         with caplog.at_level(logging.ERROR):
-            ids = await docsearch.aadd_texts(["ok text", "bad text"])
+            with pytest.raises(WeaviateBatchError, match="Failed to add 1 of 2"):
+                await docsearch.aadd_texts(["ok text", "bad text"])
 
-    # All ids are still returned (consistent with the sync path)
-    assert len(ids) == 2
     mock_collection.data.insert_many.assert_awaited_once()
     assert "Failed to add object: failed-uuid-123" in caplog.text
     assert "Reason: shard overloaded" in caplog.text
@@ -870,7 +873,13 @@ def test_logging_configuration() -> None:
 def test_add_texts_batch_failed_objects(
     mock_weaviate_client: MagicMock, caplog: Any
 ) -> None:
-    """Test handling of failed objects in add_texts method."""
+    """Failed objects in add_texts are logged AND raised.
+
+    Here the single object fails (all-failed), so add_texts raises
+    ``WeaviateInsertManyAllFailedError`` -- mirroring the async insert_many path.
+    """
+    from weaviate.exceptions import WeaviateInsertManyAllFailedError
+
     # Mock client
     mock_client = MagicMock()
     mock_collection = MagicMock()
@@ -904,12 +913,57 @@ def test_add_texts_batch_failed_objects(
 
         # Capture logs
         with caplog.at_level(logging.ERROR):
-            # Call add_texts which should process failed objects
-            store.add_texts(["test"])
+            # Call add_texts which should log the failure and then raise
+            with pytest.raises(WeaviateInsertManyAllFailedError):
+                store.add_texts(["test"])
 
             # Verify error was logged
             assert "Failed to add object: test-uuid" in caplog.text
             assert "Test failure message" in caplog.text
+
+
+def test_add_texts_partial_failed_objects(
+    mock_weaviate_client: MagicMock, caplog: Any
+) -> None:
+    """Partial failures in add_texts are logged AND raised as WeaviateBatchError.
+
+    Two objects are sent and one fails, so it is a partial failure (not
+    all-failed) and add_texts raises ``WeaviateBatchError`` rather than
+    silently returning ids for the object that was never stored.
+    """
+    from weaviate.exceptions import WeaviateBatchError
+
+    mock_client = MagicMock()
+    mock_collection = MagicMock()
+    mock_client.collections.get.return_value = mock_collection
+
+    # One of the two objects failed to index.
+    failed_obj = MagicMock()
+    failed_obj.original_uuid = "bad-uuid"
+    failed_obj.message = "shard overloaded"
+
+    mock_client.batch = MagicMock()
+    mock_client.batch.dynamic.return_value.__enter__.return_value = MagicMock()
+    mock_client.batch.failed_objects = [failed_obj]
+
+    with patch.object(WeaviateVectorStore, "__init__", return_value=None):
+        store = WeaviateVectorStore(
+            client=mock_client, index_name="test", text_key="text"
+        )
+        store._client = mock_client
+        store._embedding = FakeEmbeddings()
+        store._index_name = "test"
+        store._text_key = "text"
+        store._collection = mock_collection
+        store._query_attrs = ["text"]
+        store._multi_tenancy_enabled = False
+
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(WeaviateBatchError, match="Failed to add 1 of 2"):
+                store.add_texts(["ok text", "bad text"])
+
+        assert "Failed to add object: bad-uuid" in caplog.text
+        assert "shard overloaded" in caplog.text
 
 
 def test_max_marginal_relevance_search_no_embedding(

--- a/libs/weaviate/tests/unit_tests/test_vectorstores_additional.py
+++ b/libs/weaviate/tests/unit_tests/test_vectorstores_additional.py
@@ -1175,5 +1175,7 @@ async def test_aadd_texts_with_generator_input(
 
     assert len(ids) == 3
     mock_collection.data.insert_many.assert_awaited_once()
-    (inserted_batch,) = mock_collection.data.insert_many.await_args.args
+    await_args = mock_collection.data.insert_many.await_args
+    assert await_args is not None
+    (inserted_batch,) = await_args.args
     assert len(inserted_batch) == 3

--- a/libs/weaviate/tests/unit_tests/test_vectorstores_additional.py
+++ b/libs/weaviate/tests/unit_tests/test_vectorstores_additional.py
@@ -386,6 +386,50 @@ async def test_aadd_texts_raises_on_partial_insert_many_errors(
 
 
 @pytest.mark.asyncio
+async def test_aadd_texts_raises_all_failed_when_every_object_errors(
+    mock_weaviate_client: MagicMock, embedding: Any, caplog: Any
+) -> None:
+    """When every object is reported in ``result.errors``, raise all-failed.
+
+    ``insert_many`` normally raises ``WeaviateInsertManyAllFailedError`` itself
+    when all objects fail, but some client versions return the failures in
+    ``result.errors`` instead. In that case ``aadd_texts`` must still honor the
+    documented all-failed contract rather than raising ``WeaviateBatchError``.
+    """
+    from weaviate.exceptions import WeaviateInsertManyAllFailedError
+
+    docsearch = WeaviateVectorStore(
+        client=mock_weaviate_client,
+        index_name="TestIndex",
+        text_key="text",
+        embedding=embedding,
+        client_async=MagicMock(),
+    )
+    docsearch._client_async = MagicMock()
+    docsearch._embedding = embedding
+    docsearch._text_key = "text"
+    docsearch._multi_tenancy_enabled = False
+
+    # Both objects fail -> insert_many returns (does not raise)
+    err0 = MagicMock(original_uuid="uuid-0", message="boom 0")
+    err1 = MagicMock(original_uuid="uuid-1", message="boom 1")
+    insert_result = MagicMock()
+    insert_result.errors = {0: err0, 1: err1}
+
+    mock_collection = MagicMock()
+    mock_collection.data.insert_many = AsyncMock(return_value=insert_result)
+
+    @asynccontextmanager
+    async def fake_tenant_context(tenant: Any = None) -> AsyncGenerator[Any, None]:
+        yield mock_collection
+
+    with patch.object(docsearch, "_atenant_context", fake_tenant_context):
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(WeaviateInsertManyAllFailedError):
+                await docsearch.aadd_texts(["bad one", "bad two"])
+
+
+@pytest.mark.asyncio
 async def test_max_marginal_relevance_without_embeddings(
     mock_weaviate_client: MagicMock,
 ) -> None:

--- a/libs/weaviate/tests/unit_tests/test_vectorstores_integration.py
+++ b/libs/weaviate/tests/unit_tests/test_vectorstores_integration.py
@@ -669,36 +669,43 @@ def test_ingest_bad_documents(
     index_name = f"TestIndex_{uuid.uuid4().hex}"
     text_key = "page_content"
 
+    good_doc_uuid, bad_doc_uuid = uuids
+
     with caplog.at_level(logging.ERROR):
-        _ = WeaviateVectorStore.from_documents(
-            documents=docs,
-            embedding=consistent_embedding,
-            client=weaviate_client,
-            index_name=index_name,
-            text_key=text_key,
-            uuids=uuids,
-        )
+        # A partial batch failure is surfaced as a weaviate-native error rather
+        # than silently dropping the bad object (see add_texts contract).
+        with pytest.raises(weaviate.exceptions.WeaviateBatchError) as exc_info:
+            _ = WeaviateVectorStore.from_documents(
+                documents=docs,
+                embedding=consistent_embedding,
+                client=weaviate_client,
+                index_name=index_name,
+                text_key=text_key,
+                uuids=uuids,
+            )
 
-        good_doc_uuid, bad_doc_uuid = uuids
+    # the bad doc should be reported, the good one should not
+    assert str(bad_doc_uuid) in str(exc_info.value)
+    assert "_additional" in str(exc_info.value)
+    assert "reserved property name" in str(exc_info.value)
+    assert str(good_doc_uuid) not in str(exc_info.value)
 
-        # the bad doc should generate a log message
-        # Use a more flexible pattern that will match error messages
-        # regardless of the exact format
-        assert str(bad_doc_uuid) in caplog.text
-        assert "_additional" in caplog.text
-        assert "reserved property name" in caplog.text
-        assert good_doc_uuid not in caplog.text
+    # the bad doc should also generate a log message
+    assert str(bad_doc_uuid) in caplog.text
+    assert "_additional" in caplog.text
+    assert "reserved property name" in caplog.text
+    assert str(good_doc_uuid) not in caplog.text
 
-        # the good doc should still be ingested
-        total_docs = (
-            weaviate_client.collections.get(index_name)
-            .aggregate.over_all(total_count=True)
-            .total_count
-        )
-        assert total_docs == 1
-        assert weaviate_client.collections.get(index_name).query.fetch_object_by_id(
-            good_doc_uuid
-        )
+    # the good doc should still be ingested despite the raised error
+    total_docs = (
+        weaviate_client.collections.get(index_name)
+        .aggregate.over_all(total_count=True)
+        .total_count
+    )
+    assert total_docs == 1
+    assert weaviate_client.collections.get(index_name).query.fetch_object_by_id(
+        good_doc_uuid
+    )
 
 
 @pytest.mark.parametrize("auto_limit, expected_num_docs", [(0, 4), (1, 3)])

--- a/libs/weaviate/tests/unit_tests/test_vectorstores_integration_async.py
+++ b/libs/weaviate/tests/unit_tests/test_vectorstores_integration_async.py
@@ -814,37 +814,44 @@ async def test_ingest_bad_documents(
     index_name = f"TestIndex_{uuid.uuid4().hex}"
     text_key = "page_content"
 
+    good_doc_uuid, bad_doc_uuid = uuids
+
     with caplog.at_level(logging.ERROR):
-        _ = await WeaviateVectorStore.afrom_documents(
-            documents=docs,
-            embedding=consistent_embedding,
-            client=weaviate_client,
-            client_async=weaviate_client_async,
-            index_name=index_name,
-            text_key=text_key,
-            uuids=uuids,
-        )
+        # A partial batch failure is surfaced as a weaviate-native error rather
+        # than silently dropping the bad object (see aadd_texts contract).
+        with pytest.raises(weaviate.exceptions.WeaviateBatchError) as exc_info:
+            _ = await WeaviateVectorStore.afrom_documents(
+                documents=docs,
+                embedding=consistent_embedding,
+                client=weaviate_client,
+                client_async=weaviate_client_async,
+                index_name=index_name,
+                text_key=text_key,
+                uuids=uuids,
+            )
 
-        good_doc_uuid, bad_doc_uuid = uuids
+    # the bad doc should be reported, the good one should not
+    assert str(bad_doc_uuid) in str(exc_info.value)
+    assert "_additional" in str(exc_info.value)
+    assert "reserved property name" in str(exc_info.value)
+    assert str(good_doc_uuid) not in str(exc_info.value)
 
-        # the bad doc should generate a log message
-        # Use a more flexible pattern that will match error messages
-        # regardless of the exact format
-        assert str(bad_doc_uuid) in caplog.text
-        assert "_additional" in caplog.text
-        assert "reserved property name" in caplog.text
-        assert good_doc_uuid not in caplog.text
+    # the bad doc should also generate a log message
+    assert str(bad_doc_uuid) in caplog.text
+    assert "_additional" in caplog.text
+    assert "reserved property name" in caplog.text
+    assert str(good_doc_uuid) not in caplog.text
 
-        # the good doc should still be ingested
-        result = await weaviate_client_async.collections.get(
-            index_name
-        ).aggregate.over_all(total_count=True)
-        total_docs = result.total_count
-        assert total_docs == 1
-        doc = await weaviate_client_async.collections.get(
-            index_name
-        ).query.fetch_object_by_id(good_doc_uuid)
-        assert doc is not None
+    # the good doc should still be ingested despite the raised error
+    result = await weaviate_client_async.collections.get(index_name).aggregate.over_all(
+        total_count=True
+    )
+    total_docs = result.total_count
+    assert total_docs == 1
+    doc = await weaviate_client_async.collections.get(
+        index_name
+    ).query.fetch_object_by_id(good_doc_uuid)
+    assert doc is not None
 
 
 @pytest.mark.parametrize("auto_limit, expected_num_docs", [(0, 4), (1, 3)])

--- a/libs/weaviate/tests/unit_tests/test_vectorstores_unit.py
+++ b/libs/weaviate/tests/unit_tests/test_vectorstores_unit.py
@@ -249,3 +249,28 @@ def test_vectorstore_with_multi_tenancy_bool_false() -> None:
 
     # Should create config with multi-tenancy disabled
     assert vectorstore.schema["MultiTenancyConfig"]["enabled"] is False
+
+
+def test_add_texts_raises_error_on_failed_objects() -> None:
+    """Test that add_texts raises ValueError when batch operations fail."""
+    from unittest.mock import MagicMock, Mock
+
+    mock_client = MagicMock()
+    mock_client.collections.exists.return_value = True
+    mock_config = mock_client.collections.get.return_value.config.get.return_value
+    mock_config.multi_tenancy_config.enabled = False
+    
+    # Mock failed batch object
+    failed_obj = Mock()
+    failed_obj.original_uuid = "test-uuid-123"
+    failed_obj.message = "Test error message"
+    mock_client.batch.failed_objects = [failed_obj]
+    
+    vectorstore = WeaviateVectorStore(
+        client=mock_client,
+        index_name="TestClass",
+        text_key="text",
+    )
+    
+    with pytest.raises(ValueError, match="Failed to add 1 object\\(s\\) to Weaviate"):
+        vectorstore.add_texts(["test text"])

--- a/libs/weaviate/tests/unit_tests/test_vectorstores_unit.py
+++ b/libs/weaviate/tests/unit_tests/test_vectorstores_unit.py
@@ -314,3 +314,28 @@ def test_vectorstore_with_multi_tenancy_bool_false() -> None:
 
     # Should create config with multi-tenancy disabled
     assert vectorstore.schema["MultiTenancyConfig"]["enabled"] is False
+
+
+def test_add_texts_raises_error_on_failed_objects() -> None:
+    """Test that add_texts raises ValueError when batch operations fail."""
+    from unittest.mock import MagicMock, Mock
+
+    mock_client = MagicMock()
+    mock_client.collections.exists.return_value = True
+    mock_config = mock_client.collections.get.return_value.config.get.return_value
+    mock_config.multi_tenancy_config.enabled = False
+    
+    # Mock failed batch object
+    failed_obj = Mock()
+    failed_obj.original_uuid = "test-uuid-123"
+    failed_obj.message = "Test error message"
+    mock_client.batch.failed_objects = [failed_obj]
+    
+    vectorstore = WeaviateVectorStore(
+        client=mock_client,
+        index_name="TestClass",
+        text_key="text",
+    )
+    
+    with pytest.raises(ValueError, match="Failed to add 1 object\\(s\\) to Weaviate"):
+        vectorstore.add_texts(["test text"])

--- a/libs/weaviate/tests/unit_tests/test_vectorstores_unit.py
+++ b/libs/weaviate/tests/unit_tests/test_vectorstores_unit.py
@@ -317,25 +317,32 @@ def test_vectorstore_with_multi_tenancy_bool_false() -> None:
 
 
 def test_add_texts_raises_error_on_failed_objects() -> None:
-    """Test that add_texts raises ValueError when batch operations fail."""
+    """Test that add_texts raises when batch operations fail.
+
+    Here the single object fails (all-failed), so add_texts raises the
+    weaviate-native ``WeaviateInsertManyAllFailedError`` instead of silently
+    returning ids for objects that were never stored.
+    """
     from unittest.mock import MagicMock, Mock
+
+    from weaviate.exceptions import WeaviateInsertManyAllFailedError
 
     mock_client = MagicMock()
     mock_client.collections.exists.return_value = True
     mock_config = mock_client.collections.get.return_value.config.get.return_value
     mock_config.multi_tenancy_config.enabled = False
-    
+
     # Mock failed batch object
     failed_obj = Mock()
     failed_obj.original_uuid = "test-uuid-123"
     failed_obj.message = "Test error message"
     mock_client.batch.failed_objects = [failed_obj]
-    
+
     vectorstore = WeaviateVectorStore(
         client=mock_client,
         index_name="TestClass",
         text_key="text",
     )
-    
-    with pytest.raises(ValueError, match="Failed to add 1 object\\(s\\) to Weaviate"):
+
+    with pytest.raises(WeaviateInsertManyAllFailedError):
         vectorstore.add_texts(["test text"])


### PR DESCRIPTION
## Description

Fixes langchain-ai/langchain#35572

Previously, `WeaviateVectorStore.add_texts()` only logged errors when batch operations failed, but still returned all IDs (including failed ones). This causes silent failures, especially in FastAPI apps where logs aren't visible.

## Changes

- `add_texts()` / `aadd_texts()` now surface failed insertions as **weaviate-native exceptions** instead of silently returning ids for objects that were never stored:
  - `WeaviateInsertManyAllFailedError` — when *every* object fails.
  - `WeaviateBatchError` — when *some (but not all)* objects fail (partial failure).
  - Both subclass `weaviate.exceptions.WeaviateBaseError`, so callers can `except WeaviateBaseError` for a single catch-all.
- Failures are still logged (per-object uuid + reason) before the exception is raised.
- Fixed a latent bug where a generator passed as `texts` was consumed twice (once for embedding, once for batching), leaving the batch empty and inserting nothing. `texts` is now materialized once and reused.
- Added unit tests for the all-failed and partial-failure paths, generator input (sync + async), and updated the integration tests to expect the new failure contract.

## Impact

- **Breaking change:** code that previously ignored failures will now get exceptions.
- **Benefit:** developers immediately know when indexing fails, and no longer receive ids for objects that were never stored.

## Example

Before: silent failure — all ids returned, failures only logged.
After: raises a `WeaviateBaseError` subclass (`WeaviateBatchError` / `WeaviateInsertManyAllFailedError`) with per-object details.
