### PR TITLE
feat: send X-Weaviate-Client-Integration telemetry header

### DIFF
--- a/libs/weaviate/langchain_weaviate/vectorstores.py
+++ b/libs/weaviate/langchain_weaviate/vectorstores.py
@@ -103,9 +103,7 @@ def _register_integration(client: "weaviate.WeaviateClient") -> None:
 
         client.integrations.configure(_LangChainIntegration())
     except Exception:
-        logger.debug(
-            "Could not register langchain integration header", exc_info=True
-        )
+        logger.debug("Could not register langchain integration header", exc_info=True)
 
 
 class WeaviateVectorStore(VectorStore):

--- a/libs/weaviate/pyproject.toml
+++ b/libs/weaviate/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langchain-weaviate"
-version = "0.0.7"
+version = "0.0.6"
 description = "An integration package connecting Weaviate and LangChain"
 authors = []
 readme = "README.md"

--- a/libs/weaviate/pyproject.toml
+++ b/libs/weaviate/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langchain-weaviate"
-version = "0.0.6"
+version = "0.0.7"
 description = "An integration package connecting Weaviate and LangChain"
 authors = []
 readme = "README.md"


### PR DESCRIPTION
## What this does

Weaviate recently added server-side telemetry that tracks **client integration** usage via a new HTTP/gRPC header (weaviate/weaviate#10535):

```
X-Weaviate-Client-Integration: langchain/<version>
```

The server parses this as `name/version`, aggregates it into `clientIntegrationUsage`, and reports it alongside the existing `X-Weaviate-Client` header. Today `langchain-weaviate` sends no such header, so LangChain usage is invisible in Weaviate's telemetry.

This PR makes `WeaviateVectorStore` tag its connection with `langchain/<version>` so adoption shows up in Weaviate telemetry.

## How

- The header is registered in `WeaviateVectorStore.__init__` via the weaviate-client **public** integrations API (`client.integrations.configure(...)`), which applies it to **both HTTP and gRPC** transports on the already-connected client. All construction paths (including `from_texts`) funnel through `__init__`.
- Registration is **best-effort**: the integrations import, config class, and call are wrapped in a `try/except` that logs at debug and never raises — so an older `weaviate-client` without that API, or any failure, won't break construction.
- The reported version is the `langchain-weaviate` package version, read at runtime via `importlib.metadata` with an `"unknown"` fallback. This mirrors the client header (the version of the code making the call).

### On naming
The integration name is `langchain` (not `langchain-python`). The language is already disambiguated downstream by the co-located `X-Weaviate-Client` header (`weaviate-client-python` vs the TS client), so a language suffix would be redundant, and this keeps parity with the TS LangChain integration.

## Tests

Added unit tests (MagicMock-based, no Docker) covering: the exact header value registered, that a registration failure does not break `__init__`, and the version `"unknown"` fallback. Full suite passes locally (66 tests) with coverage at 99.65% (gate 98.06%); ruff and mypy clean.

## Notes for reviewers

- The version bump commit takes the package `0.0.6 -> 0.0.7`. Feel free to drop it if you'd rather bump as part of your own release flow — the header picks up whatever version is installed at runtime.

---

## What's new in 0.0.7 (since 0.0.6)

### Features
- **Weaviate client-integration telemetry** — sends the `X-Weaviate-Client-Integration: langchain/<version>` header so LangChain usage shows up in Weaviate telemetry (this release's headline change). — #275
- **Custom schema support** — `WeaviateVectorStore` now accepts a user-provided schema instead of always generating the default. — #254
- **simsimd made an optional dependency** — vector distance computation falls back automatically to NumPy/SciPy when `simsimd` isn't installed, lightening the default install. — #249

### Tooling / maintenance
- **CodeQL + higher coverage gate** — added CodeQL scanning and raised the test-coverage requirement; version bumps. — #253
- **Docs reference fixes.** — #248

### Dependency & security updates
~18 Dependabot bumps (PRs #250, #256–#274), including security-relevant ones: `cryptography`, `urllib3`, `authlib`, `tornado`, `idna`, `requests`, `orjson`, `protobuf`, `langsmith`.
