### PR TITLE
feat: add WeaviateTranslator for self-query retriever support

### DIFF
--- a/libs/weaviate/README.md
+++ b/libs/weaviate/README.md
@@ -35,6 +35,27 @@ pip install langchain-weaviate
 
 Please see the included [Jupyter notebook](docs/vectorstores.ipynb) for an example of how to use this package.
 
+### Self-querying retriever
+
+`WeaviateTranslator` lets you use a `WeaviateVectorStore` with LangChain's
+[self-querying retriever](https://python.langchain.com/docs/how_to/self_query/),
+which turns a natural-language question into both a search query and a structured
+metadata filter. Pass it explicitly via `structured_query_translator`:
+
+```python
+from langchain.retrievers.self_query.base import SelfQueryRetriever
+from langchain_weaviate import WeaviateTranslator, WeaviateVectorStore
+
+vectorstore = WeaviateVectorStore(...)
+retriever = SelfQueryRetriever.from_llm(
+    llm,
+    vectorstore,
+    document_contents,
+    metadata_field_info,
+    structured_query_translator=WeaviateTranslator(),
+)
+```
+
 ## Further resources
 
 - [LangChain documentation](https://python.langchain.com/docs)

--- a/libs/weaviate/langchain_weaviate/__init__.py
+++ b/libs/weaviate/langchain_weaviate/__init__.py
@@ -1,5 +1,7 @@
+from langchain_weaviate.query_constructors import WeaviateTranslator
 from langchain_weaviate.vectorstores import WeaviateVectorStore
 
 __all__ = [
+    "WeaviateTranslator",
     "WeaviateVectorStore",
 ]

--- a/libs/weaviate/langchain_weaviate/query_constructors.py
+++ b/libs/weaviate/langchain_weaviate/query_constructors.py
@@ -1,0 +1,91 @@
+"""Translate LangChain structured queries into Weaviate filters."""
+
+from datetime import datetime, timezone
+from typing import Tuple
+
+from langchain_core.structured_query import (
+    Comparator,
+    Comparison,
+    Operation,
+    Operator,
+    StructuredQuery,
+    Visitor,
+)
+from weaviate.classes.query import Filter
+from weaviate.collections.classes.filters import _Filters
+
+
+class WeaviateTranslator(Visitor):
+    """Translate `Weaviate` internal query language elements to valid filters.
+
+    This powers the LangChain self-querying retriever for
+    :class:`~langchain_weaviate.vectorstores.WeaviateVectorStore`. Because the
+    vectorstore is built on ``weaviate-client`` v4, the translator emits
+    :class:`weaviate.classes.query.Filter` objects (passed through to the
+    ``filters`` argument of the underlying search) rather than the legacy v3
+    GraphQL ``where`` filter dictionaries.
+
+    Example:
+        .. code-block:: python
+
+            from langchain.retrievers.self_query.base import SelfQueryRetriever
+            from langchain_weaviate.query_constructors import WeaviateTranslator
+
+            retriever = SelfQueryRetriever.from_llm(
+                llm,
+                vectorstore,
+                document_contents,
+                metadata_field_info,
+                structured_query_translator=WeaviateTranslator(),
+            )
+    """
+
+    allowed_operators = [Operator.AND, Operator.OR]
+    """Subset of allowed logical operators."""
+
+    allowed_comparators = [
+        Comparator.EQ,
+        Comparator.NE,
+        Comparator.GTE,
+        Comparator.LTE,
+        Comparator.LT,
+        Comparator.GT,
+    ]
+    """Subset of allowed logical comparators."""
+
+    def visit_operation(self, operation: Operation) -> _Filters:
+        self._validate_func(operation.operator)
+        operands = [arg.accept(self) for arg in operation.arguments]
+        if operation.operator == Operator.AND:
+            return Filter.all_of(operands)
+        return Filter.any_of(operands)
+
+    def visit_comparison(self, comparison: Comparison) -> _Filters:
+        self._validate_func(comparison.comparator)
+        prop = Filter.by_property(comparison.attribute)
+        value = comparison.value
+        if isinstance(value, dict) and value.get("type") == "date":
+            # An ISO 8601 date is converted to a timezone-aware datetime, which
+            # the weaviate-client v4 filter API expects for date properties.
+            value = datetime.strptime(value["date"], "%Y-%m-%d").replace(
+                tzinfo=timezone.utc
+            )
+        # https://weaviate.io/developers/weaviate/api/graphql/filters
+        comparator_map = {
+            Comparator.EQ: prop.equal,
+            Comparator.NE: prop.not_equal,
+            Comparator.GT: prop.greater_than,
+            Comparator.GTE: prop.greater_or_equal,
+            Comparator.LT: prop.less_than,
+            Comparator.LTE: prop.less_or_equal,
+        }
+        return comparator_map[comparison.comparator](value)
+
+    def visit_structured_query(
+        self, structured_query: StructuredQuery
+    ) -> Tuple[str, dict]:
+        if structured_query.filter is None:
+            kwargs: dict = {}
+        else:
+            kwargs = {"filters": structured_query.filter.accept(self)}
+        return structured_query.query, kwargs

--- a/libs/weaviate/tests/unit_tests/query_constructors/test_weaviate.py
+++ b/libs/weaviate/tests/unit_tests/query_constructors/test_weaviate.py
@@ -1,0 +1,156 @@
+from datetime import datetime, timezone
+
+from langchain_core.structured_query import (
+    Comparator,
+    Comparison,
+    Operation,
+    Operator,
+    StructuredQuery,
+)
+from weaviate.classes.query import Filter
+
+from langchain_weaviate.query_constructors import WeaviateTranslator
+
+DEFAULT_TRANSLATOR = WeaviateTranslator()
+
+
+def test_visit_comparison() -> None:
+    comp = Comparison(comparator=Comparator.EQ, attribute="foo", value="1")
+    expected = Filter.by_property("foo").equal("1")
+    actual = DEFAULT_TRANSLATOR.visit_comparison(comp)
+    assert expected == actual
+
+
+def test_visit_comparison_integer() -> None:
+    comp = Comparison(comparator=Comparator.GTE, attribute="foo", value=1)
+    expected = Filter.by_property("foo").greater_or_equal(1)
+    actual = DEFAULT_TRANSLATOR.visit_comparison(comp)
+    assert expected == actual
+
+
+def test_visit_comparison_number() -> None:
+    comp = Comparison(comparator=Comparator.GT, attribute="foo", value=1.4)
+    expected = Filter.by_property("foo").greater_than(1.4)
+    actual = DEFAULT_TRANSLATOR.visit_comparison(comp)
+    assert expected == actual
+
+
+def test_visit_comparison_boolean() -> None:
+    comp = Comparison(comparator=Comparator.NE, attribute="foo", value=False)
+    expected = Filter.by_property("foo").not_equal(False)
+    actual = DEFAULT_TRANSLATOR.visit_comparison(comp)
+    assert expected == actual
+
+
+def test_visit_comparison_datetime() -> None:
+    comp = Comparison(
+        comparator=Comparator.LTE,
+        attribute="foo",
+        value={"type": "date", "date": "2023-09-13"},
+    )
+    expected = Filter.by_property("foo").less_or_equal(
+        datetime(2023, 9, 13, tzinfo=timezone.utc)
+    )
+    actual = DEFAULT_TRANSLATOR.visit_comparison(comp)
+    assert expected == actual
+
+
+def test_visit_comparison_date() -> None:
+    comp = Comparison(
+        comparator=Comparator.LT,
+        attribute="foo",
+        value={"type": "date", "date": "2023-09-13"},
+    )
+    expected = Filter.by_property("foo").less_than(
+        datetime(2023, 9, 13, tzinfo=timezone.utc)
+    )
+    actual = DEFAULT_TRANSLATOR.visit_comparison(comp)
+    assert expected == actual
+
+
+def test_visit_operation_and() -> None:
+    op = Operation(
+        operator=Operator.AND,
+        arguments=[
+            Comparison(comparator=Comparator.EQ, attribute="foo", value="hello"),
+            Comparison(
+                comparator=Comparator.GTE,
+                attribute="bar",
+                value={"type": "date", "date": "2023-09-13"},
+            ),
+            Comparison(comparator=Comparator.LTE, attribute="abc", value=1.4),
+        ],
+    )
+    expected = Filter.all_of(
+        [
+            Filter.by_property("foo").equal("hello"),
+            Filter.by_property("bar").greater_or_equal(
+                datetime(2023, 9, 13, tzinfo=timezone.utc)
+            ),
+            Filter.by_property("abc").less_or_equal(1.4),
+        ]
+    )
+    actual = DEFAULT_TRANSLATOR.visit_operation(op)
+    # `_FilterAnd` does not implement ``__eq__``, so compare structurally.
+    assert type(actual) is type(expected)
+    assert actual.filters == expected.filters
+
+
+def test_visit_operation_or() -> None:
+    op = Operation(
+        operator=Operator.OR,
+        arguments=[
+            Comparison(comparator=Comparator.EQ, attribute="foo", value="hello"),
+            Comparison(comparator=Comparator.EQ, attribute="bar", value="world"),
+        ],
+    )
+    expected = Filter.any_of(
+        [
+            Filter.by_property("foo").equal("hello"),
+            Filter.by_property("bar").equal("world"),
+        ]
+    )
+    actual = DEFAULT_TRANSLATOR.visit_operation(op)
+    assert type(actual) is type(expected)
+    assert actual.filters == expected.filters
+
+
+def test_visit_structured_query_no_filter() -> None:
+    query = "What is the capital of France?"
+    structured_query = StructuredQuery(query=query, filter=None)
+    expected = (query, {})
+    actual = DEFAULT_TRANSLATOR.visit_structured_query(structured_query)
+    assert expected == actual
+
+
+def test_visit_structured_query_comparison() -> None:
+    query = "What is the capital of France?"
+    comp = Comparison(comparator=Comparator.EQ, attribute="foo", value="1")
+    structured_query = StructuredQuery(query=query, filter=comp)
+    expected = (query, {"filters": Filter.by_property("foo").equal("1")})
+    actual = DEFAULT_TRANSLATOR.visit_structured_query(structured_query)
+    assert expected == actual
+
+
+def test_visit_structured_query_operation() -> None:
+    query = "What is the capital of France?"
+    op = Operation(
+        operator=Operator.AND,
+        arguments=[
+            Comparison(comparator=Comparator.EQ, attribute="foo", value=2),
+            Comparison(comparator=Comparator.EQ, attribute="bar", value="baz"),
+        ],
+    )
+    structured_query = StructuredQuery(query=query, filter=op)
+    expected_filter = Filter.all_of(
+        [
+            Filter.by_property("foo").equal(2),
+            Filter.by_property("bar").equal("baz"),
+        ]
+    )
+    actual_query, actual_kwargs = DEFAULT_TRANSLATOR.visit_structured_query(
+        structured_query
+    )
+    assert actual_query == query
+    assert type(actual_kwargs["filters"]) is type(expected_filter)
+    assert actual_kwargs["filters"].filters == expected_filter.filters


### PR DESCRIPTION
## Summary

Migrates `WeaviateTranslator` from `langchain-community` so the LangChain [self-querying retriever](https://python.langchain.com/docs/how_to/self_query/) works with `WeaviateVectorStore`. Closes #228.

## Problem

`WeaviateTranslator` converts an LLM-generated structured query into a metadata filter for the self-query retriever. It lived in `langchain-community` and had no replacement in this package, which is the one Weaviate class still blocking deprecation in community (see the discussion in langchain-ai/langchain#29757).

## Solution

The community implementation targeted the **weaviate-client v3** GraphQL `where` filter format (a dict returned under the `where_filter` key). This package is built on **weaviate-client v4**, whose search API (`collection.query.hybrid(..., filters=...)`) expects `weaviate.classes.query.Filter` objects. A verbatim copy would emit a kwarg the vectorstore can't consume.

So the translator emits v4 `Filter` objects instead:
- comparators map to `equal` / `not_equal` / `greater_than` / `greater_or_equal` / `less_than` / `less_or_equal`;
- `AND` / `OR` map to `Filter.all_of` / `Filter.any_of`;
- date values are converted to timezone-aware `datetime` objects (what the v4 client expects), instead of RFC3339 strings;
- the result is returned under the `filters` key so it flows straight into the vectorstore's search.

Because langchain's built-in translator auto-discovery only knows the old community `Weaviate` vectorstore, users pass it explicitly:

```python
retriever = SelfQueryRetriever.from_llm(
    llm, vectorstore, document_contents, metadata_field_info,
    structured_query_translator=WeaviateTranslator(),
)
```

## Changes

- `langchain_weaviate/query_constructors.py` — new `WeaviateTranslator`.
- `langchain_weaviate/__init__.py` — export `WeaviateTranslator`.
- `tests/unit_tests/query_constructors/test_weaviate.py` — unit tests mirroring the community suite (eq/ne/int/float/bool/date, `AND`/`OR`, structured query) adapted to v4 `Filter` objects.
- `README.md` — self-query retriever usage note.

## How to test

```bash
cd libs/weaviate
make test TEST_FILE=tests/unit_tests/query_constructors/
```

All new tests pass; the new module has 100% unit-test coverage; `ruff` and `mypy` are clean.

## Breaking changes

None — this is purely additive.
