### PR TITLE
release: 0.0.8

### DIFF
--- a/libs/weaviate/pyproject.toml
+++ b/libs/weaviate/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "langchain-weaviate"
-version = "0.0.7"
+version = "0.0.8"
 description = "An integration package connecting Weaviate and LangChain"
 authors = []
 readme = "README.md"


### PR DESCRIPTION
Bumps `langchain-weaviate` from 0.0.7 → 0.0.8.

## What's included since v0.0.7
- Async support via optional `WeaviateAsyncClient` (#233)
- Telemetry header change: `langchain` → `langchain-python` (#279)
- Dependency bumps (#278, #280)

## Release
Version-only bump in `libs/weaviate/pyproject.toml`. After merge, trigger the `release` workflow (`workflow_dispatch`, `working-directory: libs/weaviate`) to publish to PyPI and cut the `libs/weaviate/v0.0.8` tag.